### PR TITLE
Fix substitution detection when order quantity column missing

### DIFF
--- a/warehouse_shortage_report.py
+++ b/warehouse_shortage_report.py
@@ -285,8 +285,11 @@ def main():
                 orders_keys = _make_key(merged[ord_desc_col], merged[ord_pack_col])
         
             # Heuristic: warehouse system sets Order Qty = 0 for substituted lines.
-            # We match keys *and* require Order Qty == 0 to be safe.
-            is_sub = orders_keys.isin(subs_key_set) & (merged[oc["ord"]] == 0)
+            # We match keys *and* require the numeric Order Qty == 0 to be safe.  Using
+            # the normalised `_Ord` column avoids KeyError when the raw column is
+            # absent and keeps the comparison in numeric space.
+            ord_qty = merged["_Ord"].fillna(0)
+            is_sub = orders_keys.isin(subs_key_set) & (ord_qty == 0)
         
         merged["_IsSubstituted"] = is_sub
 


### PR DESCRIPTION
## Summary
- ensure substitution detection relies on the normalised `_Ord` values
- avoid KeyErrors when the raw order quantity column is absent in the dataset
- keep substitution check numeric to prevent string-based mismatches

## Testing
- python -m compileall warehouse_shortage_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d68e66d104832db22dec6d2719e9fd